### PR TITLE
eslintの設定

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,9 @@ export default tseslint.config(
         'warn',
         { allowConstantExport: true },
       ],
+        "no-undef": "error",
+        "no-unused-vars": "error",
+        "react-prop-types": "off", 
     },
   },
 )


### PR DESCRIPTION
### "no-undef": "error"
意味：定義されていない変数を使用するとエラー
目的：タイプミスや未インポートの変数使用を防止

### "no-unused-vars": "error"
意味：定義されたけど使われていない変数・引数があるとエラー
目的：不要なコードを除去し、可読性と保守性を向上させるため

### "react/prop-types": "off"
意味：React コンポーネントの propTypes バリデーションの使用を チェックしない。
目的：TypeScript を使用している場合など、prop-types による型チェックが不要なケースで警告を無効にするため。


